### PR TITLE
fixed post request url

### DIFF
--- a/TGDP_Website/Publish/Home.html
+++ b/TGDP_Website/Publish/Home.html
@@ -240,7 +240,7 @@ function retrieve_data () {
         xhr.onreadystatechange = sendDataCallback;
         console.log("test" + data);
         console.log(body)
-        xhr.open("POST", ".netlify/functions/Javascript_Backend.mjs", true);
+        xhr.open("POST", "/.netlify/functions/Javascript_Backend.mjs", true);
         send_data(body);
         /*const response = await fetch("https://127.0.0.1:443/Functions/Javascript_Backend.js", {
             method: "POST",


### PR DESCRIPTION
Post request url was missing a "/" at the beginning of the url. This may be why there is an unknown 404 error when attempting to do a post request. 