### PR TITLE
Changed xhr status condition, file path for post request

### DIFF
--- a/TGDP_Website/Publish/Home.html
+++ b/TGDP_Website/Publish/Home.html
@@ -240,7 +240,7 @@ function retrieve_data () {
         xhr.onreadystatechange = sendDataCallback;
         console.log("test" + data);
         console.log(body)
-        xhr.open("POST", "/.netlify/functions/TGDP_Website/Javascript_Backend.mjs", true);
+        xhr.open("POST", "/.netlify/functions/Javascript_Backend.mjs", true);
         send_data(body);
         /*const response = await fetch("https://127.0.0.1:443/Functions/Javascript_Backend.js", {
             method: "POST",


### PR DESCRIPTION
The xhr status was changed from 201 to 200. The file path for the post request was also changed in hopes that it will fix the error. Currently the xhr status returns a 404 error as does the send_data function. 